### PR TITLE
feat(layout): add level sections

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -30,6 +30,48 @@
                 @include('layouts.partials.notification')
 
                 <main class="container hero is-large">
+                    @isset($title)
+                        <div class="level">
+                            <div class="level-left">
+                                <div class="level-item">
+                                    <h1 class="title is-1">
+                                        {{ $title }}
+                
+                                        @isset($action)
+                                            / {{ $action }}
+                                        @endisset
+                                    </h1>
+                                </div>
+                            </div>
+
+                            @hasSection('addons')
+                                <div class="level-right">
+                                    <div class="level-item">
+                                        @yield('addons')
+                                    </div>
+                                </div>
+                            @endif
+                        </div>
+                    @endisset
+
+                    <div class="level">
+                        @hasSection('addons-left')
+                            <div class="level-left">
+                                <div class="level-item">
+                                    @yield('addons-left')
+                                </div>
+                            </div>
+                        @endif
+    
+                        @hasSection('addons-right')
+                            <div class="level-right">
+                                <div class="level-item">
+                                    @yield('addons-right')
+                                </div>
+                            </div>
+                        @endif
+                    </div>
+
                     @yield('content')
                 </main>
             </section>


### PR DESCRIPTION
Titel toegevoegd + op drie plaatsen kunnen add-ons worden geplaatst (zie onderstaande screenshots):

![image](https://github.com/steenbokdev/de-gouden-draak/assets/155370942/c3eb5bd9-cd82-40a9-912e-b05cb86db4b6)
(Add-ons: links en rechts)

![image](https://github.com/steenbokdev/de-gouden-draak/assets/155370942/efe8e85a-2df2-40ef-a5c3-35f66b603ddf)
(Add-ons: default)

De linkse en rechte add-ons kunnen afzonderlijk van elkaar worden gebruikt.